### PR TITLE
Add modal and theme persistence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Alvin Lennarthsson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ My personal portfolio website built with Next.js and Tailwind CSS. View it live 
 
 ## Features
 
-- 🌓 Dark/Light mode
+- 🌓 Dark/Light mode with theme persistence
+- 🖼️ Masonry project grid with smooth hover reveals
+- 🔍 Modal popups for detailed project info
 - 📱 Fully responsive design
-- 🎯 Modern UI with smooth animations
+- 🎯 Modern UI with Framer Motion animations
 - ⚡ Fast performance
 - 🎨 Clean and minimalist design
 
@@ -45,4 +47,5 @@ npm run build
 
 ## License
 
-Copyright © 2024 Alvin Lennarthsson. All rights reserved.
+This project is released under the MIT License. See [LICENSE](LICENSE) for
+details.

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,54 @@
+import { motion, AnimatePresence } from 'framer-motion';
+import { ReactNode, useEffect } from 'react';
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export default function Modal({ isOpen, onClose, children }: ModalProps) {
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    if (isOpen) document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [isOpen, onClose]);
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.div
+            className="absolute inset-0 bg-black/80"
+            onClick={onClose}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          />
+          <motion.div
+            className="relative bg-gray-900 text-white p-8 rounded-xl max-w-lg w-full shadow-xl ring-1 ring-cyan-500 neon-glow"
+            initial={{ scale: 0.9, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.9, opacity: 0 }}
+          >
+            <button
+              onClick={onClose}
+              className="absolute top-2 right-2 text-gray-400 hover:text-white"
+              aria-label="Close modal"
+            >
+              ×
+            </button>
+            {children}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,29 +1,38 @@
 import { motion } from 'framer-motion';
 import { fadeInUp, staggerContainer } from '@/utils/animations';
 import { FaGithub } from 'react-icons/fa';
+import { useState } from 'react';
+import Modal from './Modal';
 
-interface ProjectCardProps {
+export interface Project {
   title: string;
   description: string;
   technologies: string[];
   githubUrl: string;
-  isDark: boolean;
   impact?: string;
 }
 
-function ProjectCard({ title, description, technologies, githubUrl, isDark, impact }: ProjectCardProps) {
+interface ProjectCardProps {
+  project: Project;
+  isDark: boolean;
+  onOpen: () => void;
+}
+
+function ProjectCard({ project, isDark, onOpen }: ProjectCardProps) {
+  const { title, description, technologies, githubUrl, impact } = project;
   return (
     <motion.div
-      className={`masonry-item p-8 rounded-xl ${isDark ? 'bg-gray-800/90' : 'bg-white/90'} shadow-lg border ${isDark ? 'border-gray-700' : 'border-gray-200'} backdrop-blur-sm`}
+      onClick={onOpen}
+      className={`masonry-item cursor-pointer p-8 rounded-xl ${isDark ? 'bg-gray-800/90' : 'bg-white/90'} shadow-lg border ${isDark ? 'border-gray-700' : 'border-gray-200'} backdrop-blur-sm`}
       variants={{
         initial: { y: 20, opacity: 0 },
         animate: { y: 0, opacity: 1 },
       }}
       whileHover={{
-        scale: 1.02,
+        scale: 1.05,
         boxShadow: isDark
-          ? '0 20px 25px -5px rgba(0, 0, 0, 0.3)'
-          : '0 20px 25px -5px rgba(0, 0, 0, 0.1)',
+          ? '0 0 15px rgba(0,240,255,0.6)'
+          : '0 0 15px rgba(0,240,255,0.4)',
       }}
       transition={{ duration: 0.2 }}
     >
@@ -64,7 +73,20 @@ interface ProjectsProps {
   isDark: boolean;
 }
 
+const projects: Project[] = [
+  {
+    title: 'Portfolio Website',
+    description:
+      'A modern, responsive portfolio website built with Next.js and Tailwind CSS. Features dark mode support, smooth animations, and a clean, professional design showcasing my full-stack development skills.',
+    technologies: ['Next.js', 'TypeScript', 'Tailwind CSS', 'Framer Motion'],
+    githubUrl: 'https://github.com/lennartAlvin/Portfolio',
+    impact: 'Personal project demonstrating modern web development practices',
+  },
+];
+
 export default function Projects({ isDark }: ProjectsProps) {
+  const [active, setActive] = useState<Project | null>(null);
+
   return (
     <motion.section
       className="py-16"
@@ -83,15 +105,27 @@ export default function Projects({ isDark }: ProjectsProps) {
         className="masonry columns-1 md:columns-2"
         variants={staggerContainer}
       >
-        <ProjectCard
-          title="Portfolio Website"
-          description="A modern, responsive portfolio website built with Next.js and Tailwind CSS. Features dark mode support, smooth animations, and a clean, professional design showcasing my full-stack development skills."
-          technologies={['Next.js', 'TypeScript', 'Tailwind CSS', 'Framer Motion']}
-          githubUrl="https://github.com/lennartAlvin/Portfolio"
-          isDark={isDark}
-          impact="Personal project demonstrating modern web development practices"
-        />
+        {projects.map((p) => (
+          <ProjectCard key={p.title} project={p} isDark={isDark} onOpen={() => setActive(p)} />
+        ))}
       </motion.div>
+      <Modal isOpen={active !== null} onClose={() => setActive(null)}>
+        {active && (
+          <div>
+            <h3 className="text-2xl font-bold mb-4">{active.title}</h3>
+            <p className="mb-4">{active.description}</p>
+            <a
+              href={active.githubUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center space-x-2 text-cyan-400 hover:underline"
+            >
+              <FaGithub className="w-5 h-5" />
+              <span>View on GitHub</span>
+            </a>
+          </div>
+        )}
+      </Modal>
     </motion.section>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Head from 'next/head';
 import { motion } from 'framer-motion';
 
@@ -10,6 +10,19 @@ import Contact from '@/components/Contact';
 
 export default function Home() {
   const [isDarkMode, setIsDarkMode] = useState(false);
+
+  useEffect(() => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem('theme') : null;
+    if (stored === 'dark') {
+      setIsDarkMode(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('theme', isDarkMode ? 'dark' : 'light');
+    }
+  }, [isDarkMode]);
 
   return (
     <div className={`min-h-screen ${isDarkMode ? 'dark bg-gray-900' : 'bg-white'}`}>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -29,4 +29,8 @@
       margin-bottom: 0;
     }
   }
+
+  .neon-glow {
+    box-shadow: 0 0 10px rgba(0, 240, 255, 0.6), 0 0 20px rgba(0, 240, 255, 0.4);
+  }
 }


### PR DESCRIPTION
## Summary
- add MIT license and mention in docs
- persist dark mode preference using localStorage
- create reusable `Modal` component
- show project details in modal
- style hover with a neon glow

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685d64fbf0908324af69302629496df1