### PR TITLE
Refine dark theme colors

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -20,12 +20,12 @@ export default function About() {
         className="prose dark:prose-invert max-w-none"
         variants={fadeInUp}
       >
-        <p className="text-lg text-gray-600 dark:text-gray-300">
+        <p className="text-lg text-gray-600 dark:text-[rgba(255,255,255,0.8)]">
           I'm a 24-year-old software developer based in Alingsås, Sweden. I recently graduated from the
           University of Borås with a Bachelor's degree in Information Systems. Currently working at WIS,
           I develop and maintain applications primarily built with .NET, WinUI, and Azure DevOps environments.
         </p>
-        <p className="text-lg text-gray-600 dark:text-gray-300 mt-4">
+        <p className="text-lg text-gray-600 dark:text-[rgba(255,255,255,0.8)] mt-4">
           I'm particularly passionate about software quality, focusing heavily on clean architecture,
           API integrations, and automated testing. I have experience integrating external services and
           payment solutions into software systems, always striving for robust, maintainable solutions.

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -21,7 +21,7 @@ export default function Contact() {
         className="flex flex-col items-center space-y-6"
         variants={fadeInUp}
       >
-        <p className="text-lg text-gray-600 dark:text-gray-300 text-center max-w-2xl">
+        <p className="text-lg text-gray-600 dark:text-[rgba(255,255,255,0.8)] text-center max-w-2xl">
           I'm always interested in hearing about new opportunities, interesting projects, or just having a chat.
         </p>
         <div className="flex space-x-6">
@@ -30,7 +30,7 @@ export default function Contact() {
             target="_blank"
             rel="noopener noreferrer"
             aria-label="GitHub"
-            className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors transform hover:scale-110 duration-200"
+            className="text-gray-600 dark:text-[rgba(255,255,255,0.8)] hover:text-gray-900 dark:hover:text-white transition-colors transform hover:scale-110 duration-200"
           >
             <FaGithub className="w-8 h-8" />
           </a>
@@ -39,14 +39,14 @@ export default function Contact() {
             target="_blank"
             rel="noopener noreferrer"
             aria-label="LinkedIn"
-            className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors transform hover:scale-110 duration-200"
+            className="text-gray-600 dark:text-[rgba(255,255,255,0.8)] hover:text-gray-900 dark:hover:text-white transition-colors transform hover:scale-110 duration-200"
           >
             <FaLinkedin className="w-8 h-8" />
           </a>
           <a
             href="mailto:alvin.lennarthsson@gmail.com"
             aria-label="Email"
-            className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors transform hover:scale-110 duration-200"
+            className="text-gray-600 dark:text-[rgba(255,255,255,0.8)] hover:text-gray-900 dark:hover:text-white transition-colors transform hover:scale-110 duration-200"
           >
             <FaEnvelope className="w-8 h-8" />
           </a>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -4,20 +4,20 @@ import { fadeInUp, staggerContainer } from '@/utils/animations';
 export default function Hero() {
   return (
     <motion.section
-      className="flex flex-col md:flex-row items-center justify-between py-16 px-4 rounded-2xl mb-8 bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-800 dark:to-gray-900"
+      className="flex flex-col md:flex-row items-center justify-between py-16 px-4 rounded-2xl mb-8 bg-gradient-to-br from-gray-50 to-gray-100 dark:from-[#1e1e2f] dark:to-[#121212]"
       initial="initial"
       whileInView="animate"
       viewport={{ once: true }}
       variants={staggerContainer}
     >
       <motion.div className="md:w-1/2 space-y-6 md:pr-8" variants={fadeInUp}>
-        <h1 className="text-4xl md:text-6xl font-bold text-gray-900 dark:text-white bg-clip-text text-transparent bg-gradient-to-r from-gray-900 to-gray-600 dark:from-white dark:to-gray-300">
+        <h1 className="text-4xl md:text-6xl font-bold text-gray-900 dark:text-white bg-clip-text text-transparent bg-gradient-to-r from-[#00f0ff] via-[#a100ff] to-[#ff00c8]">
           Hi, I'm Alvin Lennarthsson
         </h1>
-        <p className="text-xl text-gray-600 dark:text-gray-300">
+        <p className="text-xl text-gray-600 dark:text-[rgba(255,255,255,0.8)]">
           A software developer who enjoys crafting complete solutions from backend to frontend.
         </p>
-        <p className="text-lg text-gray-600 dark:text-gray-300">
+        <p className="text-lg text-gray-600 dark:text-[rgba(255,255,255,0.8)]">
           Working with C# and .NET for backend systems while embracing modern frontend technologies,
           I strive to build applications that are both reliable and user-friendly. I'm passionate about
           clean code and always eager to learn new ways to improve my craft.

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -33,7 +33,7 @@ export default function Modal({ isOpen, onClose, children }: ModalProps) {
             exit={{ opacity: 0 }}
           />
           <motion.div
-            className="relative bg-gray-900 text-white p-8 rounded-xl max-w-lg w-full shadow-xl ring-1 ring-cyan-500 neon-glow"
+            className="relative bg-[#1e1e2f] text-white p-8 rounded-xl max-w-lg w-full shadow-xl ring-1 ring-[#00f0ff] neon-glow"
             initial={{ scale: 0.9, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
             exit={{ scale: 0.9, opacity: 0 }}

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -23,7 +23,7 @@ function ProjectCard({ project, isDark, onOpen }: ProjectCardProps) {
   return (
     <motion.div
       onClick={onOpen}
-      className={`masonry-item cursor-pointer p-8 rounded-xl ${isDark ? 'bg-gray-800/90' : 'bg-white/90'} shadow-lg border ${isDark ? 'border-gray-700' : 'border-gray-200'} backdrop-blur-sm`}
+      className={`masonry-item cursor-pointer p-8 rounded-xl ${isDark ? 'bg-[#1e1e2f]/90' : 'bg-white/90'} shadow-lg border ${isDark ? 'border-[#121212]' : 'border-gray-200'} backdrop-blur-sm`}
       variants={{
         initial: { y: 20, opacity: 0 },
         animate: { y: 0, opacity: 1 },
@@ -37,7 +37,7 @@ function ProjectCard({ project, isDark, onOpen }: ProjectCardProps) {
       transition={{ duration: 0.2 }}
     >
       <h3 className="text-2xl font-bold mb-4 text-gray-900 dark:text-white">{title}</h3>
-      <p className="text-gray-600 dark:text-gray-300 mb-6 leading-relaxed">{description}</p>
+      <p className="text-gray-600 dark:text-[rgba(255,255,255,0.8)] mb-6 leading-relaxed">{description}</p>
       {impact && (
         <div className="mb-6 flex items-center space-x-2">
           <span className="w-2 h-2 rounded-full bg-green-500"></span>
@@ -48,7 +48,7 @@ function ProjectCard({ project, isDark, onOpen }: ProjectCardProps) {
         {technologies.map((tech) => (
           <span
             key={tech}
-            className="px-3 py-1 rounded-full text-sm bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 font-medium"
+            className="px-3 py-1 rounded-full text-sm bg-[#ff00c8]/10 dark:bg-[#ff00c8]/30 text-[#ff0059] dark:text-[#ff00c8] font-medium"
           >
             {tech}
           </span>
@@ -58,7 +58,7 @@ function ProjectCard({ project, isDark, onOpen }: ProjectCardProps) {
         href={githubUrl}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center space-x-2 text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 font-medium"
+        className="inline-flex items-center space-x-2 text-[#00e0d1] dark:text-[#00f0ff] hover:text-[#00e0d1] dark:hover:text-[#00f0ff] font-medium"
         whileHover={{ scale: 1.05 }}
         whileTap={{ scale: 0.95 }}
       >
@@ -118,7 +118,7 @@ export default function Projects({ isDark }: ProjectsProps) {
               href={active.githubUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center space-x-2 text-cyan-400 hover:underline"
+              className="inline-flex items-center space-x-2 text-[#00f0ff] hover:underline"
             >
               <FaGithub className="w-5 h-5" />
               <span>View on GitHub</span>

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -13,8 +13,8 @@ function SkillCategory({ title, skills, isDark }: SkillCategoryProps) {
     <motion.div
       className={`p-6 rounded-xl backdrop-blur-sm ${
         isLearning
-          ? `${isDark ? 'bg-blue-900/20' : 'bg-blue-50'} border-2 ${isDark ? 'border-blue-500/30' : 'border-blue-200'}`
-          : `${isDark ? 'bg-gray-800/90' : 'bg-white/90'} border ${isDark ? 'border-gray-700' : 'border-gray-200'}`
+          ? `${isDark ? 'bg-[#ff00c8]/20' : 'bg-[#ff00c8]/10'} border-2 ${isDark ? 'border-[#ff00c8]/30' : 'border-[#ff00c8]/20'}`
+          : `${isDark ? 'bg-[#1e1e2f]/90' : 'bg-white/90'} border ${isDark ? 'border-[#121212]' : 'border-gray-200'}`
       } shadow-lg`}
       variants={{
         initial: { y: 20, opacity: 0 },
@@ -32,7 +32,7 @@ function SkillCategory({ title, skills, isDark }: SkillCategoryProps) {
         <h3 className="text-xl font-semibold text-gray-900 dark:text-white">{title}</h3>
         {isLearning && (
           <motion.span
-            className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200"
+            className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-[#ff00c8]/10 dark:bg-[#ff00c8]/30 text-[#ff0059] dark:text-[#ff00c8]"
             animate={{
               scale: [1, 1.05, 1],
               opacity: [1, 0.8, 1],
@@ -51,11 +51,11 @@ function SkillCategory({ title, skills, isDark }: SkillCategoryProps) {
         {skills.map((skill) => (
           <li
             key={skill}
-            className="text-gray-600 dark:text-gray-300 flex items-center space-x-2"
+            className="text-gray-600 dark:text-[rgba(255,255,255,0.8)] flex items-center space-x-2"
           >
             <span
               className={`w-2 h-2 rounded-full ${
-                isLearning ? 'bg-blue-500 dark:bg-blue-400' : 'bg-blue-500 dark:bg-blue-400'
+                isLearning ? 'bg-[#00f0ff] dark:bg-[#00e0d1]' : 'bg-[#00f0ff] dark:bg-[#00e0d1]'
               }`}
             ></span>
             <span>{skill}</span>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -25,7 +25,7 @@ export default function Home() {
   }, [isDarkMode]);
 
   return (
-    <div className={`min-h-screen ${isDarkMode ? 'dark bg-gray-900' : 'bg-white'}`}>
+    <div className={`min-h-screen ${isDarkMode ? 'dark bg-gradient-to-b from-[#0d0d0d] via-[#121212] to-[#1e1e2f]' : 'bg-white'}`}> 
       <Head>
         <title>Alvin Lennarthsson - Software Developer</title>
         <meta name="description" content="Portfolio of Alvin Lennarthsson - Software Developer specializing in C#, .NET, and API integration" />
@@ -36,7 +36,7 @@ export default function Home() {
         {/* Dark Mode Toggle */}
         <motion.button
           onClick={() => setIsDarkMode(!isDarkMode)}
-          className="fixed top-4 right-4 p-2 rounded-full bg-gray-200 dark:bg-gray-700 hover:scale-110 transition-transform"
+          className="fixed top-4 right-4 p-2 rounded-full bg-gray-200 dark:bg-[#1e1e2f] hover:scale-110 transition-transform"
           whileHover={{ scale: 1.1 }}
           whileTap={{ scale: 0.95 }}
         >
@@ -51,7 +51,7 @@ export default function Home() {
       </main>
 
       <motion.footer
-        className="py-8 text-center text-gray-600 dark:text-gray-300"
+        className="py-8 text-center text-gray-600 dark:text-[rgba(255,255,255,0.8)]"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ delay: 0.5 }}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -31,6 +31,6 @@
   }
 
   .neon-glow {
-    box-shadow: 0 0 10px rgba(0, 240, 255, 0.6), 0 0 20px rgba(0, 240, 255, 0.4);
+    box-shadow: 0 0 10px rgba(0, 240, 255, 0.6), 0 0 20px rgba(161, 0, 255, 0.4);
   }
 }


### PR DESCRIPTION
## Summary
- use gradient background for dark mode
- polish hero colors
- tweak skills, projects, and contact sections to new palette
- style modal and neon glow

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685d6d6ebf048324ac4857eb86df668c